### PR TITLE
feat: Improve model for custom collapse state and custom nav on click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
 # Change Log
 
-All notable changes to the "httpfile-navigation" extension will be documented in this file.
+All notable changes to the "navigation-powerups" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
 ## [Unreleased]
 
-- Initial release

--- a/src/editors/vscode/TreeNavigationAdapter.ts
+++ b/src/editors/vscode/TreeNavigationAdapter.ts
@@ -26,8 +26,13 @@ export default class TreeNavigationAdapter implements vscode.TreeDataProvider<vs
 
 	private convertToTreeItems(nodes: NavigationNode[]): vscode.TreeItem[] {
 		return nodes.map(node => {
-			const treeItem = new vscode.TreeItem(node.getName(), node.getChildren().length > 0 ? vscode.TreeItemCollapsibleState.Collapsed : vscode.TreeItemCollapsibleState.None);
-			if(node.getChildren().length === 0) {
+			var treeItemCollapsibleState = vscode.TreeItemCollapsibleState.None;
+			if(node.getChildren().length > 0)
+				treeItemCollapsibleState = node.getInitialStateAsCollapsed() ? vscode.TreeItemCollapsibleState.Collapsed : vscode.TreeItemCollapsibleState.Expanded;
+
+			const treeItem = new vscode.TreeItem(node.getName(), treeItemCollapsibleState);
+
+			if(node.getChildren().length === 0 || node.getNavigateToLineOnClick()) {
 				treeItem.command = {
 					command: navigationCommandName,
 					title: 'Navigate',

--- a/src/model/NavigationNode.ts
+++ b/src/model/NavigationNode.ts
@@ -3,12 +3,22 @@ export default class NavigationNode {
     private lineNumber: number | null;
     private level: number;
     private children: NavigationNode[];
+    private initialStateAsCollapsed: boolean;
+    private navigateToLineOnClick: boolean
 
-    constructor(name: string, level: number = 0, lineNumber: number | null = null) {
+    constructor(
+        name: string, 
+        level: number = 0, 
+        lineNumber: number | null = null,
+        initialStateAsCollapsed: boolean = false,
+        navigateToLineOnClick: boolean = true
+    ) {
         this.name = name;
         this.level = level;
         this.lineNumber = lineNumber;
         this.children = [];
+        this.initialStateAsCollapsed = initialStateAsCollapsed;
+        this.navigateToLineOnClick = navigateToLineOnClick;
     }
 
     addChild(child: NavigationNode): void {
@@ -29,5 +39,13 @@ export default class NavigationNode {
 
     getLineNumber(): number | null {
         return this.lineNumber;
+    }
+
+    getInitialStateAsCollapsed(): boolean {
+        return false;
+    }
+
+    getNavigateToLineOnClick(): boolean {
+        return this.navigateToLineOnClick;
     }
 }


### PR DESCRIPTION
This PR aims to add the possibility for the parser to set  node ` initialStateAsCollapsed`  and `navigateToLineOnClick` props in the model that way: 

- The parser can customize if the navigation sections should start as opened or closed
- Also, the parser component can make the section title clickable and navigable or not