### PR TITLE
build/fix: Fix publish pipeline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,11 +30,3 @@ jobs:
           vsce package
           vsce publish -p ${{ secrets.MARKETPLACE_TOKEN }}
 
-      - name: Upload VSIX to GitHub Releases
-        uses: actions/upload-release-asset@v1
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: './navigation-powerups.vsix'
-          asset_name: 'navigation-powerups.vsix'
-          asset_content_type: application/zip
-


### PR DESCRIPTION
Removing the problematic vsix artfact upload step from the publish pipeline as it isn't necessary